### PR TITLE
Backwards compatible fix for #27

### DIFF
--- a/octoprint_navbartemp/static/js/navbartemp.js
+++ b/octoprint_navbartemp/static/js/navbartemp.js
@@ -7,6 +7,17 @@ $(function() {
         self.raspiTemp = ko.observable();
         self.isRaspi = ko.observable(false);
 
+        self.formatBarTemperature = function(toolName, actual, target) {
+            var output = toolName + ": " + _.sprintf("%.1f&deg;C", actual);
+
+            if (target) {
+                var sign = (target >= actual) ? " \u21D7 " : " \u21D8 ";
+                output += sign + _.sprintf("%.1f&deg;C", target);
+            }
+
+            return output;
+        };
+
         self.onBeforeBinding = function () {
             self.settings = self.global_settings.settings.plugins.navbartemp;
         };
@@ -33,14 +44,3 @@ $(function() {
         ["#navbar_plugin_navbartemp", "#settings_plugin_navbartemp"]
     ]);
 });
-
-function formatBarTemperature(toolName, actual, target) {
-    var output = toolName + ": " + _.sprintf("%.1f&deg;C", actual);
-
-    if (target) {
-        var sign = (target >= actual) ? " \u21D7 " : " \u21D8 ";
-        output += sign + _.sprintf("%.1f&deg;C", target);
-    }
-
-    return output;
-};

--- a/octoprint_navbartemp/templates/navbartemp_navbar.jinja2
+++ b/octoprint_navbartemp/templates/navbartemp_navbar.jinja2
@@ -7,5 +7,5 @@
 </div>
 
 <script type="text/html" id="navbartemp-template">
-    <span data-bind="html: formatBarTemperature(name(), actual(), target())"></span>
+    <span data-bind="html: $root.formatBarTemperature(name(), actual(), target())"></span>
 </script>

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 plugin_identifier = "navbartemp"
 plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-NavbarTemp"
-plugin_version = "0.8"
+plugin_version = "0.9"
 plugin_description = "Displays temperatures on navbar"
 plugin_author = "Jarek Szczepanski"
 plugin_author_email = "imrahil@imrahil.com"


### PR DESCRIPTION
Moved format method into view model - no need to clutter the global
namespace (and if so starting with 1.3.6 that needs to be done
*explicitly*, see http://octoprint.org/blog/2017/12/01/heads-up-plugin-authors/)

I also adjusted the version so all you, @imrahil, should need to do here
is merge this and tag a new release, and you should be set.

Closes #27