### PR TITLE
Fixed crash when match returns None when not running on a Raspberry Pi

### DIFF
--- a/octoprint_navbartemp/libs/sbc.py
+++ b/octoprint_navbartemp/libs/sbc.py
@@ -42,6 +42,8 @@ class SBCFactory(object):
         # Match a line like 'Hardware   : BCM2709'
         match = re.search('Hardware\s+:\s+(\w+)', cpuinfo, flags=re.MULTILINE | re.IGNORECASE)
 
+        if match is None: return
+
         if match.group(1) in self.piSocTypes:
             logger.info("Broadcom detected")
             return True


### PR DESCRIPTION
There was a crash that prevented the plugin from loading in octoprint due to re.search returning None causing match.group to raise an error