### PR TITLE
Python 3.3 and higher no longer adds a version to sys.platform

### DIFF
--- a/octoprint_navbartemp/__init__.py
+++ b/octoprint_navbartemp/__init__.py
@@ -37,7 +37,7 @@ class NavBarPlugin(octoprint.plugin.StartupPlugin,
         self._logger.debug("Custom cmd name %r" % self.cmd_name)
         self._logger.debug("Custom cmd %r" % self.cmd)
 
-        if sys.platform == "linux2":
+        if sys.platform.startswith("linux"):
             self.sbc = SBCFactory().factory(self._logger)
             if self.debugMode:
                 self.sbc.is_supported = True


### PR DESCRIPTION
On Python 3.3 or higher, ``sys.platform`` no longer includes a version number. This causes the code that checks whether we can read the SoC temperature to fail. This PR fixes that issue.