### PR TITLE
sys.platform no longer includes version

### DIFF
--- a/octoprint_navbartemp/__init__.py
+++ b/octoprint_navbartemp/__init__.py
@@ -37,7 +37,7 @@ class NavBarPlugin(octoprint.plugin.StartupPlugin,
         self._logger.debug("Custom cmd name %r" % self.cmd_name)
         self._logger.debug("Custom cmd %r" % self.cmd)
 
-        if sys.platform == "linux2":
+        if sys.platform.startswith("linux"):
             self.sbc = SBCFactory().factory(self._logger)
             if self.debugMode:
                 self.sbc.is_supported = True


### PR DESCRIPTION
``sys.platform`` on Python 3.3 and above no longer includes a version number. That makes the check for SoC support fail. This fix resolves that issue.