### PR TITLE
Add BCM2711 as supported SoC

### DIFF
--- a/octoprint_navbartemp/__init__.py
+++ b/octoprint_navbartemp/__init__.py
@@ -20,7 +20,7 @@ class NavBarPlugin(octoprint.plugin.StartupPlugin,
 
     def __init__(self):
         # Array of raspberry pi SoC's to check against, saves having a large if/then statement later
-        self.piSocTypes = (["BCM2708", "BCM2709", "BCM2835"])
+        self.piSocTypes = (["BCM2708", "BCM2709", "BCM2835", "BCM2711"])
         self.debugMode = False  # to simulate temp on Win/Mac
         self.displayRaspiTemp = None
         self._checkTempTimer = None

--- a/octoprint_navbartemp/libs/sbc.py
+++ b/octoprint_navbartemp/libs/sbc.py
@@ -14,7 +14,7 @@ import re
 
 class SBCFactory(object):
     # Array of raspberry pi SoC's to check against, saves having a large if/then statement later
-    piSocTypes = (["BCM2708", "BCM2709", "BCM2835"])
+    piSocTypes = (["BCM2708", "BCM2709", "BCM2835", "BCM2711"])
 
     # Create based on class name:
     def factory(self, logger):


### PR DESCRIPTION
The latest Raspbian kernel (installed if you do a ``apt upgrade``) now correctly reports the processor on the Raspberry Pi 4B as a BCM2711. This PR adds BCM2711 to the list of supported SoCs.