### PR TITLE
consolidate vcgencmd between versions

### DIFF
--- a/octoprint_navbartemp/libs/sbc.py
+++ b/octoprint_navbartemp/libs/sbc.py
@@ -102,7 +102,7 @@ class SBC(object):
 class RPi(SBC):
     def __init__(self, logger):
         self.is_supported = True
-        self.temp_cmd = "/opt/vc/bin/vcgencmd measure_temp"
+        self.temp_cmd = "/usr/bin/vcgencmd measure_temp"
         self.parse_pattern = "=(.*)'"
         self._logger = logger
 


### PR DESCRIPTION
Pushing previous PR to devel branch now after making changes based on that branch. Also learned more about the proper pathways for working on Octprint and plugins based on documentation instead of just making the code change. Tested more properly using plugin devel principles against Bullseye 32 and 64 versions along with current Buster version.